### PR TITLE
Updated: Python 3.9-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.9-buster
 
 LABEL "maintainer"="Roald Nefs <info@roaldnefs.com>"
 LABEL "repository"="https://github.com/roaldnefs/salt-lint-action"


### PR DESCRIPTION
Updated to python 3.9 (buster). We might also want to have a look at checkout@v2 as it is stable for quite a while now.